### PR TITLE
Readme update

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 ![CI/CD Pipeline](../../docs/cicd-pipeline.png)
 
-Two workflow files run automatically on every push.
+Two workflow files handle CI/CD. `ci.yml` runs on every push to every branch. `cd.yml` runs on pushes to `master` and on pull requests targeting `master`.
 
 ---
 
@@ -53,7 +53,7 @@ For each VM:
 1. Copies the service's `docker-compose.yaml` to `~/legacyProject/<service>/` via SCP. The monitoring VM also receives `prometheus.yml`.
 2. Assembles `~/legacyProject/<service>/.env` from individual secrets (`DB_HOST`, `DB_USER`, `DB_PASSWORD`, etc.) using `printf` — never echoed to logs.
 3. Pulls the new image and runs `docker compose up --wait`, blocking until all healthchecks pass within 60 seconds.
-4. On failure, rolls back to `:<image>:latest-stable` (the last confirmed-healthy image) for services with a custom image.
+4. On failure, rolls back to `<image>:latest-stable` (the last confirmed-healthy image) for services with a custom image.
 
 App, database, and monitoring VMs have no public IP and are reached via the network VM as a jump host (`SSH_PROXY_HOST`).
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -8,8 +8,8 @@
 
 | Tool | Purpose | Install |
 |---|---|---|
-| [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) | Create VMs | Windows: `winget install Microsoft.AzureCLI`<br>macOS: `brew install azure-cli`<br>Linux (Ubuntu/Debian): `curl -sL https://aka.ms/InstallAzureCLIDeb &#124; sudo bash`<br>Other Linux: [install guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux) |
-| Azure subscription | Quota for 4 × Standard_B2als_v2 VMs + 1 Standard public IP | Azure for Students works |
+| [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) | Create VMs | Windows: `winget install Microsoft.AzureCLI`<br>macOS: `brew install azure-cli`<br>Linux (Ubuntu/Debian): `curl -sL https://aka.ms/InstallAzureCLIDeb &#124; sudo bash`<br>Other Linux: [install guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux) |
+| Azure subscription | Quota for 4 × Standard_B1s VMs + 1 Standard public IP | Azure for Students works |
 | `openssl` | Generate DB/Grafana passwords | Pre-installed on macOS/Linux; included in Git Bash / WSL on Windows |
 | SSH key at `~/.ssh/azure_key` | VM auth | Auto-generated if missing |
 | [GitHub CLI](https://cli.github.com/) | Set secrets automatically | Windows: `winget install GitHub.cli`<br>macOS: `brew install gh`<br>Linux (Ubuntu/Debian): `sudo apt install gh`<br>Other Linux: [install guide](https://cli.github.com/) |
@@ -28,8 +28,8 @@ gh auth login --scopes read:packages
 
 Run once to provision infrastructure and perform the initial container deployment. Subsequent deployments are handled by GitHub Actions on every push.
 
-1. Creates resource group `recipe-cookbook` and a shared VNet (`10.0.0.0/16`) in `norwayeast`
-2. Provisions four VMs (all `Standard_B2als_v2`, Ubuntu 22.04):
+1. Creates resource group `recipe-cookbook` and a shared VNet (`10.0.0.0/16`) in the selected region (see [Azure Region](#azure-region))
+2. Provisions four VMs (all `Standard_B1s`, Ubuntu 22.04):
    - **nginx VM** — public IP, ports 22/80 open (443 not configured — HTTPS not active)
    - **app VM** — no public IP, port 3000 reachable within VNet only
    - **postgres VM** — no public IP, port 5432 reachable from app VM only
@@ -65,7 +65,7 @@ The third case is the most common when using accounts with restricted quotas (e.
 az account list-locations --query "[].{Name:name, DisplayName:displayName}" --output table
 ```
 
-Pick any region from the `Name` column where you have quota for 4 × `Standard_B2als_v2` VMs and 1 Standard public IP. `Standard_B2als_v2` is available in virtually all regions — if a region appears in the list, it will almost certainly work.
+Pick any region from the `Name` column where you have quota for 4 × `Standard_B1s` VMs and 1 Standard public IP. `Standard_B1s` is available in virtually all regions — if a region appears in the list, it will almost certainly work.
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ The application is deployed and running at the static public IP below.
 |---|---|---|
 | Azure CLI | Windows: `winget install Microsoft.AzureCLI`<br>macOS: `brew install azure-cli`<br>Linux (Ubuntu/Debian): `curl -sL https://aka.ms/InstallAzureCLIDeb &#124; sudo bash`<br>Other Linux: [install guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux) | `az login` |
 | GitHub CLI | Windows: `winget install GitHub.cli`<br>macOS: `brew install gh`<br>Linux (Ubuntu/Debian): `sudo apt install gh`<br>Other Linux: [install guide](https://cli.github.com/) | `gh auth login --scopes read:packages` |
-| Azure subscription | Azure for Students works | quota for 4 × Standard_B2als_v2 VMs + 1 Standard public IP |
+| Azure subscription | Azure for Students works | quota for 4 × Standard_B1s VMs + 1 Standard public IP |
 | `openssl` | Pre-installed on macOS/Linux; included in Git Bash / WSL on Windows | — |
 | SSH key | Auto-generated at `~/.ssh/azure_key` if missing | — |
 
@@ -101,7 +101,7 @@ bash infrastructure/azure-teardown.sh
 | Reverse proxy | Nginx |
 | Monitoring | Prometheus + Grafana |
 | Container registry | GHCR |
-| Cloud | Azure (4 × Standard_B2als_v2 VMs) |
+| Cloud | Azure (4 × Standard_B1s VMs) |
 
 Go with `net/http` was chosen over the legacy Python/Flask stack for its performance and simplicity — it is compiled, statically typed, and the standard library HTTP server requires no external framework dependencies.
 


### PR DESCRIPTION
## PR Description
Syncs all README files to match the actual infrastructure configuration and fixes several factual inaccuracies.

## Changes Made
VM size corrected (Standard_B2als_v2 → Standard_B1s) across readme.md, infrastructure/README.md (×3 occurrences), fixing a mismatch with the actual script

infrastructure/README.md: Step 1 no longer hardcodes norwayeast as the region — now references the Azure Region section which explains auto-detection

infrastructure/README.md: Azure CLI link updated from deprecated docs.microsoft.com to learn.microsoft.com

.github/workflows/README.md: Opening sentence corrected — cd.yml does not run on every push, only on pushes to master and PRs targeting master

.github/workflows/README.md: Rollback tag format fixed (:<image>:latest-stable → <image>:latest-stable)

## Reason for Change
The azure-setup.sh script uses Standard_B1s VMs, but all three READMEs documented Standard_B2als_v2. Several other smaller inaccuracies were also found during a full review of all documentation.

## Type
Select at least one (multiple allowed):
- [ ] Update to `main.go`
- [x] Text Update
- [ ] Feature
- [ ] Bug
